### PR TITLE
refactor to use hyper's tokio branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ description = "A Rust Wrapper for the FaceBook Messenger Bot API"
 
 [dependencies]
 hyper = { git = "https://github.com/hyperium/hyper", branch = "master" }
+hyper-tls = { git = "https://github.com/hyperium/hyper-tls", branch = "master" }
 tokio-core = "0.1.6"
 futures = "0.1.11"
 url = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmessenger"
-version = "0.0.4"
+version = "0.1.0"
 authors = ["nocotan <noconoco.lib@gmail.com>"]
 repository = "https://github.com/nocotan/rmessenger"
 keywords = ["facebook", "bot"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ description = "A Rust Wrapper for the FaceBook Messenger Bot API"
 hyper = { git = "https://github.com/hyperium/hyper", branch = "master" }
 tokio-core = "0.1.6"
 futures = "0.1.11"
+url = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ hyper-tls = { git = "https://github.com/hyperium/hyper-tls", branch = "master" }
 tokio-core = "0.1.6"
 futures = "0.1.11"
 url = "1.4.0"
+pretty_env_logger = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ readme = "README.md"
 description = "A Rust Wrapper for the FaceBook Messenger Bot API"
 
 [dependencies]
-multipart = "0.8.1"
-hyper = "0.9.10"
+hyper = { git = "https://github.com/hyperium/hyper", branch = "master" }
+tokio-core = "0.1.6"
+futures = "0.1.11"

--- a/examples/send_text_message.rs
+++ b/examples/send_text_message.rs
@@ -1,0 +1,52 @@
+extern crate futures;
+extern crate hyper;
+extern crate hyper_tls;
+extern crate tokio_core;
+extern crate pretty_env_logger;
+extern crate rmessenger;
+
+use std::env;
+
+
+fn main() {
+    pretty_env_logger::init().unwrap();
+
+    let access_token = env::var("ACCESS_TOKEN").unwrap_or(String::new());
+    let app_secret = env::var("APP_SECRET").unwrap_or(String::new());
+    let webhook_verify_token = env::var("WEBHOOK_VERIFY_TOKEN").unwrap_or(String::new());
+
+    let recipient = match env::args().nth(1) {
+        Some(recipient) => recipient,
+        None => {
+            println!("Usage: client <recipient> <text>");
+            return;
+        }
+    };
+    let text = match env::args().nth(2) {
+        Some(text) => text,
+        None => {
+            println!("Usage: client <recipient> <text>");
+            return;
+        }
+    };
+
+    let mut core = tokio_core::reactor::Core::new().unwrap();
+    let handle = core.handle();
+    let client = hyper::Client::configure()
+        .connector(hyper_tls::HttpsConnector::new(4, &handle))
+        .build(&handle);
+
+
+    let bot = rmessenger::bot::Bot::new(client.clone(),
+                                        &access_token,
+                                        &app_secret,
+                                        &webhook_verify_token);
+
+    let message_promise = bot.send_text_message(&recipient, &text);
+
+    let response = core.run(message_promise);
+    match response {
+        Ok(res) => println!("Got response from facebook: {}", res),
+        Err(err) => println!("Got error: {:?}", err),
+    };
+}

--- a/src/bot/mod.rs
+++ b/src/bot/mod.rs
@@ -1,4 +1,8 @@
+extern crate futures;
+extern crate hyper;
+
 mod utils;
+use self::futures::future::Future;
 
 pub struct Bot {
     access_token: String,
@@ -16,7 +20,10 @@ impl Bot {
     }
 
     /// send text messages to the specified recipient.
-    pub fn send_text_message(self, recipient_id: &str, message: &str) -> String {
+    pub fn send_text_message(self,
+                             recipient_id: &str,
+                             message: &str)
+                             -> Box<Future<Item = String, Error = hyper::Error>> {
         let payload = format!("
                               {{
                                  'recipient': {{'id': {} }},
@@ -29,7 +36,10 @@ impl Bot {
     }
 
     /// send generic message to the specified recipient.
-    pub fn send_generic_message(self, recipient_id: &str, elements: &str) -> String {
+    pub fn send_generic_message(self,
+                                recipient_id: &str,
+                                elements: &str)
+                                -> Box<Future<Item = String, Error = hyper::Error>> {
         let payload = format!("
                               {{
                                 'recipient': {{'id': {} }},
@@ -50,7 +60,11 @@ impl Bot {
     }
 
     /// send button message to the specified recipient.
-    pub fn send_button_message(self, recipient_id: &str, text: &str, buttons: &str) -> String {
+    pub fn send_button_message(self,
+                               recipient_id: &str,
+                               text: &str,
+                               buttons: &str)
+                               -> Box<Future<Item = String, Error = hyper::Error>> {
         let payload = format!("
                               {{
                                 'recipient': {{'id': {} }},
@@ -73,7 +87,10 @@ impl Bot {
     }
 
     /// send file url to the specified recipient.
-    pub fn send_file_url(self, recipient_id: &str, file_url: &str) -> String {
+    pub fn send_file_url(self,
+                         recipient_id: &str,
+                         file_url: &str)
+                         -> Box<Future<Item = String, Error = hyper::Error>> {
         let payload = format!("
                               {{
                                 'recipient': {{'id': {} }},
@@ -93,7 +110,10 @@ impl Bot {
     }
 
     /// send audio url to the specified recipient.
-    pub fn send_audio_url(self, recipient_id: &str, audio_url: &str) -> String {
+    pub fn send_audio_url(self,
+                          recipient_id: &str,
+                          audio_url: &str)
+                          -> Box<Future<Item = String, Error = hyper::Error>> {
         let payload = format!("
                               {{
                                 'recipient': {{'id': {} }},
@@ -113,12 +133,11 @@ impl Bot {
     }
 
     /// send payload.
-    fn send_raw(self, payload: String) -> String {
+    fn send_raw(self, payload: String) -> Box<Future<Item = String, Error = hyper::Error>> {
         let request_endpoint = format!("{}{}", self.graph_url, "/me/messages");
         let url_request = utils::UrlRequest::new();
 
         let data = format!("{}{}", "access_token=", self.access_token).to_string();
-
 
         url_request.post(request_endpoint, data, payload)
     }

--- a/src/bot/mod.rs
+++ b/src/bot/mod.rs
@@ -1,5 +1,6 @@
 extern crate futures;
 extern crate hyper;
+extern crate hyper_tls;
 extern crate url;
 
 mod utils;
@@ -8,6 +9,7 @@ use self::url::form_urlencoded;
 
 #[derive(Clone)]
 pub struct Bot {
+    client: hyper::Client<hyper_tls::HttpsConnector>,
     access_token: String,
     app_secret: String,
     webhook_verify_token: String,
@@ -15,12 +17,17 @@ pub struct Bot {
 }
 
 impl Bot {
-    pub fn new(access_token: &str, app_secret: &str, webhook_verify_token: &str) -> Bot {
+    pub fn new(client: hyper::Client<hyper_tls::HttpsConnector>,
+               access_token: &str,
+               app_secret: &str,
+               webhook_verify_token: &str)
+               -> Bot {
         Bot {
             access_token: access_token.to_string(),
             app_secret: app_secret.to_string(),
             webhook_verify_token: webhook_verify_token.to_string(),
             graph_url: "https://graph.facebook.com/v2.7".to_string(),
+            client: client,
         }
     }
 
@@ -168,6 +175,6 @@ impl Bot {
 
         let data = format!("{}{}", "access_token=", self.access_token).to_string();
 
-        url_request.post(request_endpoint, data, payload)
+        url_request.post(self.client.clone(), request_endpoint, data, payload)
     }
 }

--- a/src/bot/mod.rs
+++ b/src/bot/mod.rs
@@ -49,7 +49,7 @@ impl Bot {
     }
 
     /// send text messages to the specified recipient.
-    pub fn send_text_message(self,
+    pub fn send_text_message(&self,
                              recipient_id: &str,
                              message: &str)
                              -> Box<Future<Item = String, Error = hyper::Error>> {
@@ -65,7 +65,7 @@ impl Bot {
     }
 
     /// send generic message to the specified recipient.
-    pub fn send_generic_message(self,
+    pub fn send_generic_message(&self,
                                 recipient_id: &str,
                                 elements: &str)
                                 -> Box<Future<Item = String, Error = hyper::Error>> {
@@ -89,7 +89,7 @@ impl Bot {
     }
 
     /// send button message to the specified recipient.
-    pub fn send_button_message(self,
+    pub fn send_button_message(&self,
                                recipient_id: &str,
                                text: &str,
                                buttons: &str)
@@ -116,7 +116,7 @@ impl Bot {
     }
 
     /// send file url to the specified recipient.
-    pub fn send_file_url(self,
+    pub fn send_file_url(&self,
                          recipient_id: &str,
                          file_url: &str)
                          -> Box<Future<Item = String, Error = hyper::Error>> {
@@ -139,7 +139,7 @@ impl Bot {
     }
 
     /// send audio url to the specified recipient.
-    pub fn send_audio_url(self,
+    pub fn send_audio_url(&self,
                           recipient_id: &str,
                           audio_url: &str)
                           -> Box<Future<Item = String, Error = hyper::Error>> {
@@ -162,7 +162,7 @@ impl Bot {
     }
 
     /// send payload.
-    fn send_raw(self, payload: String) -> Box<Future<Item = String, Error = hyper::Error>> {
+    fn send_raw(&self, payload: String) -> Box<Future<Item = String, Error = hyper::Error>> {
         let request_endpoint = format!("{}{}", self.graph_url, "/me/messages");
         let url_request = utils::UrlRequest::new();
 

--- a/src/bot/mod.rs
+++ b/src/bot/mod.rs
@@ -17,91 +17,97 @@ impl Bot {
 
     /// send text messages to the specified recipient.
     pub fn send_text_message(self, recipient_id: &str, message: &str) -> String {
-        let payload = format!(
-            "{{
-                'recipient': {{'id': {} }},
-                'message': {{'text': '{}'}}
-             }}",
-             recipient_id, message);
+        let payload = format!("
+                              {{
+                                 'recipient': {{'id': {} }},
+                                 'message': {{'text': '{}'}}
+                              }}",
+                              recipient_id,
+                              message);
 
         self.send_raw(payload.to_string())
     }
 
     /// send generic message to the specified recipient.
     pub fn send_generic_message(self, recipient_id: &str, elements: &str) -> String {
-        let payload = format!(
-            "{{
-                'recipient': {{'id': {} }},
-                'message': {{
-                  'attachment': {{
-                    'type': 'template',
-                    'payload': {{
-                      'template_type': 'generic',
-                      'elements': {}
-                    }}
-                  }}
-                }}
-            }}",
-            recipient_id, elements);
+        let payload = format!("
+                              {{
+                                'recipient': {{'id': {} }},
+                                'message': {{
+                                  'attachment': {{
+                                    'type': 'template',
+                                    'payload': {{
+                                      'template_type': 'generic',
+                                      'elements': {}
+                                    }}
+                                  }}
+                                }}
+                              }}",
+                              recipient_id,
+                              elements);
 
         self.send_raw(payload.to_string())
     }
 
     /// send button message to the specified recipient.
     pub fn send_button_message(self, recipient_id: &str, text: &str, buttons: &str) -> String {
-        let payload = format!(
-            "{{
-                'recipient': {{'id': {} }},
-                'message': {{
-                  'attachment': {{
-                    'type': 'template',
-                    'payload': {{
-                      'template_type': 'button',
-                      'text': {},
-                      'buttons': {}
-                    }}
-                  }}
-                }}
-             }}",
-             recipient_id, text, buttons);
+        let payload = format!("
+                              {{
+                                'recipient': {{'id': {} }},
+                                'message': {{
+                                  'attachment': {{
+                                    'type': 'template',
+                                    'payload': {{
+                                      'template_type': 'button',
+                                      'text': {},
+                                      'buttons': {}
+                                    }}
+                                  }}
+                                }}
+                              }}",
+                              recipient_id,
+                              text,
+                              buttons);
 
         self.send_raw(payload.to_string())
     }
 
     /// send file url to the specified recipient.
     pub fn send_file_url(self, recipient_id: &str, file_url: &str) -> String {
-        let payload = format!(
-            "{{
-                'recipient': {{'id': {} }},
-                'message': {{
-                  'attachment': {{
-                    'type': 'file',
-                    'payload': {{
-                      'url': {}
-                    }}
-                  }}
-                }}
-              }}",
-              recipient_id, file_url);
+        let payload = format!("
+                              {{
+                                'recipient': {{'id': {} }},
+                                'message': {{
+                                  'attachment': {{
+                                    'type': 'file',
+                                    'payload': {{
+                                      'url': {}
+                                    }}
+                                  }}
+                                }}
+                              }}",
+                              recipient_id,
+                              file_url);
 
         self.send_raw(payload.to_string())
     }
 
     /// send audio url to the specified recipient.
     pub fn send_audio_url(self, recipient_id: &str, audio_url: &str) -> String {
-        let payload = format!(
-            "{{
-                'recipient': {{'id': {} }},
-                'message': {{
-                  'attachment': {{
-                    'type': 'audio',
-                    'payload': {{
-                      'url': {}
-                    }}
-                  }}
-                }}
-              }}",
-              recipient_id, audio_url);
+        let payload = format!("
+                              {{
+                                'recipient': {{'id': {} }},
+                                'message': {{
+                                  'attachment': {{
+                                    'type': 'audio',
+                                    'payload': {{
+                                      'url': {}
+                                    }}
+                                  }}
+                                }}
+                              }}",
+                              recipient_id,
+                              audio_url);
 
         self.send_raw(payload.to_string())
     }

--- a/src/bot/utils.rs
+++ b/src/bot/utils.rs
@@ -1,12 +1,15 @@
+extern crate futures;
 extern crate hyper;
 extern crate core;
+extern crate tokio_core;
 
-use std::io::Read;
-
+use self::futures::future::Future;
+use self::futures::Stream;
 use self::hyper::Client;
 use self::hyper::header::{Headers, ContentType};
 use self::hyper::mime::{Mime, TopLevel, SubLevel, Attr, Value};
-
+use self::hyper::Post;
+use self::hyper::client::Request;
 
 pub struct UrlRequest {}
 
@@ -15,28 +18,36 @@ impl UrlRequest {
         UrlRequest {}
     }
 
-    pub fn post(self, url: String, data: String, body: String) -> String {
+    pub fn post(self,
+                url: String,
+                data: String,
+                body: String)
+                -> Box<Future<Item = String, Error = hyper::Error>> {
         // create request url
         let request_url = format!("{}{}{}", url, "?", data);
-
+        let url = request_url.parse::<hyper::Uri>().unwrap();
         // headers
         let mut headers = Headers::new();
         headers.set(ContentType(Mime(TopLevel::Application,
                                      SubLevel::Json,
                                      vec![(Attr::Charset, Value::Utf8)])));
 
-        // client
-        let client = Client::new();
-        let res = client
-            .post(&request_url.to_owned())
-            .headers(headers)
-            .body(&body.to_owned())
-            .send();
-
-        let mut response_body = String::new();
-        res.unwrap().read_to_string(&mut response_body).unwrap();
-        println!("{}", response_body);
-
-        response_body
+        let core = tokio_core::reactor::Core::new().unwrap();
+        let handle = core.handle();
+        let client = Client::new(&handle);
+        let mut request = Request::new(Post, url);
+        *(request.headers_mut()) = headers;
+        request.set_body(body.to_owned());
+        let fut = client
+            .request(request)
+            .and_then(|res| {
+                          res.body()
+                              .fold(Vec::new(), |mut acc, chunk| {
+                    acc.extend_from_slice(&chunk);
+                    Ok::<_, hyper::Error>(acc)
+                })
+                      })
+            .map(|vec| String::from_utf8(vec).unwrap());
+        Box::new(fut)
     }
 }

--- a/src/bot/utils.rs
+++ b/src/bot/utils.rs
@@ -2,11 +2,11 @@ extern crate futures;
 extern crate hyper;
 extern crate core;
 extern crate tokio_core;
+extern crate hyper_tls;
 
 use self::futures::future::Future;
 use self::futures::Stream;
-use self::hyper::Client;
-use self::hyper::header::{Headers, ContentType};
+use self::hyper::header::ContentType;
 use self::hyper::mime::{Mime, TopLevel, SubLevel, Attr, Value};
 use self::hyper::Post;
 use self::hyper::client::Request;
@@ -19,25 +19,21 @@ impl UrlRequest {
     }
 
     pub fn post(self,
+                client: hyper::Client<hyper_tls::HttpsConnector>,
                 url: String,
                 data: String,
                 body: String)
                 -> Box<Future<Item = String, Error = hyper::Error>> {
-        // create request url
-        let request_url = format!("{}{}{}", url, "?", data);
-        let url = request_url.parse::<hyper::Uri>().unwrap();
-        // headers
-        let mut headers = Headers::new();
-        headers.set(ContentType(Mime(TopLevel::Application,
-                                     SubLevel::Json,
-                                     vec![(Attr::Charset, Value::Utf8)])));
 
-        let core = tokio_core::reactor::Core::new().unwrap();
-        let handle = core.handle();
-        let client = Client::new(&handle);
-        let mut request = Request::new(Post, url);
-        *(request.headers_mut()) = headers;
+        let request_url = format!("{}{}{}", url, "?", data).parse().unwrap();
+        let mut request = Request::new(Post, request_url);
+        request
+            .headers_mut()
+            .set(ContentType(Mime(TopLevel::Application,
+                                  SubLevel::Json,
+                                  vec![(Attr::Charset, Value::Utf8)])));
         request.set_body(body.to_owned());
+
         let fut = client
             .request(request)
             .and_then(|res| {

--- a/src/bot/utils.rs
+++ b/src/bot/utils.rs
@@ -8,11 +8,11 @@ use self::hyper::header::{Headers, ContentType};
 use self::hyper::mime::{Mime, TopLevel, SubLevel, Attr, Value};
 
 
-pub struct UrlRequest { }
+pub struct UrlRequest {}
 
 impl UrlRequest {
     pub fn new() -> UrlRequest {
-        UrlRequest { }
+        UrlRequest {}
     }
 
     pub fn post(self, url: String, data: String, body: String) -> String {
@@ -23,15 +23,15 @@ impl UrlRequest {
         let mut headers = Headers::new();
         headers.set(ContentType(Mime(TopLevel::Application,
                                      SubLevel::Json,
-                                     vec![(Attr::Charset, Value::Utf8)])
-                                ));
+                                     vec![(Attr::Charset, Value::Utf8)])));
 
         // client
         let client = Client::new();
-        let res = client.post(&request_url.to_owned())
-                            .headers(headers)
-                            .body(&body.to_owned())
-                            .send();
+        let res = client
+            .post(&request_url.to_owned())
+            .headers(headers)
+            .body(&body.to_owned())
+            .send();
 
         let mut response_body = String::new();
         res.unwrap().read_to_string(&mut response_body).unwrap();


### PR DESCRIPTION
This is completely untested, and may not even be a good idea (chatbots are
unlikely to be performance-critical, given FB's rate limits) but I wanted
an excuse to play about with futures, and this gave me the opportunity.

I don't genuinely expect you to merge this, but I thought I should at least
make you aware of my work in case you had any comments.

My editor stomps on everything by default, and I had already made significant
progress before I realised that the diff was full of style changes. I decided
that the most sensible thing to do would be to pass the whole thing through
rustfmt first, and then rebase my functionality changes on top of the style
changes.

I will probably be writing some webhook handling code over the next week or so.
If you happen to have any HMAC verifying code kicking around (I assume you do because none of the functions in this repo can be used without working webhooks), I would appreciate being able to have a look at it. Otherwise, I will probably just port my python implementation across to rust.